### PR TITLE
bytea typecast to bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	FLASK_APP=./flask/server.py flask run -p 3001
+	FLASK_APP=./flask/server.py FLASK_ENV=development flask run -p 3001
 
 gore:
 	go build middleware.go

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ sudo lsof -i -P -n
 
 sudo service postgresql stop
 
+^ or could do 8080:5432 and it wouldn't conflict?
+
 2.
 `docker exec -it db-postgres psql -U admin`
 
@@ -73,6 +75,7 @@ Sentry sdk sends events to a Flask API (like a proxy or interceptor) which then 
 1. `docker-compose up` your getsentry/onpremise, it defaults to localhost:9000
 2. `make` runs Flask server
 3. `python app.py` using MODIFIED_dsn
+4. `localhost:9000` to see your Sentry onprem event
 
 #### doesnt' work yet
 Send events using app.py to your on-prem instance. the middleware.go sniffs the events and doesn't interrupt them like a proxy does.   
@@ -80,14 +83,6 @@ Send events using app.py to your on-prem instance. the middleware.go sniffs the 
 2. `go build middleware.go`
 3. `sudo ./gor --input-raw :9000 --middleware "./middleware" --output-http http://localhost:9000/api/2/store`
 3. `python3 app.py` using ORIGINAL_DSN
-
-## TODO
-- TODO try sending events to here from other sdk's (javascript, go)
-- TODO Save data and headers to DB after decompressing, and use a different module to load from DB and send to sentry instance
-- replaying the payload many times
-- persisting events as []bytes? https://www.postgresql.org/docs/9.0/datatype-binary.html for loading and sending, decouples the dependency on +10 platform sdk's
-- gRPC
-- get the middleware.go or even a basic go replay (gor without middleware) working
 
 
 ## Notes
@@ -123,10 +118,12 @@ https://rominirani.com/golang-tip-capturing-http-client-requests-incoming-and-ou
 
 https://golang.org/pkg/net/http/#Request  
 https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body using encoding/json instead of buger/jsonparser  
-
 gor file-server 8000
 
+```
+getsentry/sentry-python
 transport.py, core_api.py, event_manager.py
+```
 
 Working Request Headers
 ```
@@ -139,3 +136,12 @@ Working Request Headers
     'User-Agent': 'sentry.python/0.14.2'
 }
 ```
+
+```
+type(request) <class 'werkzeug.local.LocalProxy'>
+type(request.headers) <class 'werkzeug.datastructures.EnvironHeaders'>
+type(request.data) <class 'bytes'>
+200 RESPONSE and event_id b'{"id":"2e8e7ab795ed4f9fb70d172aa2b79815"}'
+```
+
+replaying the payload many times. grpc

--- a/README.md
+++ b/README.md
@@ -145,3 +145,8 @@ type(request.data) <class 'bytes'>
 ```
 
 replaying the payload many times. grpc
+
+
+MemoryView  
+https://www.postgresql.org/message-id/25EDB20679154BDBB3CBBD335184E1D7%40frank  
+https://www.postgresql.org/message-id/C2C12FD0FCE64CE8BB77765A526D3C73%40frank  

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ and
 install -r requirements.txt
 
 ## Database
-postgres.txt
-
+1.
 ```
 docker run -it --rm \
     --name db-postgres \
@@ -42,18 +41,27 @@ docker run -it --rm \
     -p 5432:5432 \
     postgres
 ```
+sudo lsof -i -P -n
 
+sudo service postgresql stop
+
+2.
 `docker exec -it db-postgres psql -U admin`
 
+```
+\l list databases
+\c choose db
+\dt list data tables
+```
+
+3.
 ```
 CREATE TABLE events(
    pk SERIAL PRIMARY KEY,
    type varchar(40) NOT NULL,
-   name varchar(40) NOT NULL
+   name varchar(40) NOT NULL,
+   data bytea
 );
-
-insert into events (type, name)
-    values ('type1', 'name1');
 ```
 
 create user admin with login password 'admin';

--- a/flask/server.py
+++ b/flask/server.py
@@ -107,18 +107,15 @@ def events():
 @app.route('/event', methods=['POST'])
 def event():
     print('/event POST')
-    insert_query = """ INSERT INTO events (type, name) VALUES (%s,%s)"""
     record = ('python', 'example')
+    insert_query = """ INSERT INTO events (type, name) VALUES (%s,%s)"""
     with db.connect() as conn:
         conn.execute(
             "INSERT INTO events (type,name) VALUES ('type2', 'name2')"
         )
         conn.close()
         print("inserted")
-        # rows = []
-        # for row in results:
-        #     rows.append(dict(row))
-        # return json.dumps(rows)
+    return 'successful'
 
 @app.route('/event-bytea', methods=['POST'])
 def event_bytea():
@@ -128,7 +125,7 @@ def event_bytea():
     record = ('python', 'example', binary)
     
     with db.connect() as conn:
-        conn.execute(insert_query, record))
+        conn.execute(insert_query, record)
         conn.close()
 
 @app.route('/test', methods=['GET'])

--- a/flask/server.py
+++ b/flask/server.py
@@ -40,6 +40,9 @@ db = create_engine('postgresql://' + USERNAME + ':' + PASSWORD + '@' + HOST + ':
 # Intercepts the payload sent by sentry_sdk in app.py, and then sends it to a Sentry instance
 @app.route('/api/2/store/', methods=['POST'])
 def api_store():
+    print('type(request)', type(request))
+    print('type(request.headers)', type(request.headers))
+    print('type(request.data)', type(request.data))
 
     headers = request.headers
     requests_headers = {
@@ -111,7 +114,7 @@ def event():
     insert_query = """ INSERT INTO events (type, name) VALUES (%s,%s)"""
     with db.connect() as conn:
         conn.execute(
-            "INSERT INTO events (type,name) VALUES ('type2', 'name2')"
+            "INSERT INTO events (type,name) VALUES ('type4', 'name4')"
         )
         conn.close()
         print("inserted")
@@ -119,7 +122,10 @@ def event():
 
 @app.route('/event-bytea', methods=['POST'])
 def event_bytea():
-    binary = request
+    # TODO different from request and request.headre but try it
+    print('/event-bytea POST')
+    binary = request.data
+    print('type(binary)', type(binary))
 
     insert_query = """ INSERT INTO events (type, name, data) VALUES (%s,%s,%s)"""
     record = ('python', 'example', binary)

--- a/flask/server.py
+++ b/flask/server.py
@@ -109,7 +109,7 @@ def event_bytea_get():
 
     with db.connect() as conn:
         results = conn.execute(
-            "SELECT * FROM events WHERE pk=9"
+            "SELECT * FROM events WHERE pk=11"
         ).fetchall()
         conn.close()
         print('results[0]', results[0])
@@ -128,14 +128,14 @@ def event_bytea_get():
         print('type(row_proxy.data)', type(row_proxy.data)) #'bytes' if you use the typecasting. 'MemoryView' if you don't use typecasting
         print('row_proxy.data', row_proxy.data)
 
-        
+        return row_proxy.data
         # strings = decompress_gzip(row_proxy.data)
         # print('strings', strings)
-
-        rows = []
-        for row in results:
-            rows.append(dict(row))
-        return json.dumps(rows)
+        
+        # rows = []
+        # for row in results:
+        #     rows.append(dict(row))
+        # return json.dumps(rows)
 
 @app.route('/event-bytea', methods=['POST'])
 def event_bytea_post():

--- a/postgres.txt
+++ b/postgres.txt
@@ -46,6 +46,11 @@ database is called 'postgres'
 -p 5432 and made sure postgresql not running locally (without docker) by `sudo lsof -i -P -n`
 
 
+# rows = []
+# for row in results:
+#     rows.append(dict(row))
+# return json.dumps(rows)
+
 
 
 

--- a/postgres.txt
+++ b/postgres.txt
@@ -1,4 +1,6 @@
 https://hub.docker.com/_/postgres
+https://www.postgresqltutorial.com/psql-commands/
+http://www.postgresonline.com/downloads/special_feature/postgresql83_psql_cheatsheet.pdf
 
 `sudo service postgresql stop` stops local postgres on 5432
 
@@ -14,19 +16,16 @@ docker run -it --rm \
 
 docker exec -it db-postgres psql -U admin
 
-1. show all databases
-2. identify db name (should be admin?) 'OR' create one if none exist
-3. create a table w/ row w/ pid, name(?), []bytes
-4. practice psql adding a row...
-5. practice reading from it from python console
-6. practice writing to it from python console (psycopg2? or sqlalchemy preferred)
-7. try writing []bytes to it as well
+1. + show all databases
+2. + identify db name (should be admin?) 'OR' create one if none exist
+3. + create a table w/ row w/ pid, name(?), []bytes
+4. + psql adding a row...
+5. +read from it from python console
+6. +write from python console (psycopg2? or sqlalchemy preferred)
+7. write parameterized
 
-
-https://www.postgresqltutorial.com/psql-commands/
-http://www.postgresonline.com/downloads/special_feature/postgresql83_psql_cheatsheet.pdf
-
-
+sqlalchemy uses LargeBinary for bytea  
+psygopg2  
 
 CREATE TABLE events(
    pk SERIAL PRIMARY KEY,
@@ -34,20 +33,20 @@ CREATE TABLE events(
    name varchar(40) NOT NULL
 );
 
-insert into events (type, name)
-    values ('type1', 'name1');
+INSERT INTO events (type, name)
+    VALUES ('type1', 'name1');
 
-
-create user admin with login password 'admin';
-
-8:25p
-database is called 'postgres'
--p 5432 and made sure postgresql not running locally (without docker) by `sudo lsof -i -P -n`
-
-10:38p
 ALTER TABLE events
     ADD COLUMN data BYTEA;
 
-\dt data tables , show them
-\l show all databases
-\c use a db
+create user admin with login password 'admin';
+
+database is called 'postgres'
+
+-p 5432 and made sure postgresql not running locally (without docker) by `sudo lsof -i -P -n`
+
+
+
+
+
+


### PR DESCRIPTION
this code:
```
    def bytea2bytes(value, cur):
        m = psycopg2.BINARY(value, cur)
        if m is not None:
            return m.tobytes()
    BYTEA2BYTES = psycopg2.extensions.new_type(
        psycopg2.BINARY.values, 'BYTEA2BYTES', bytea2bytes)
    psycopg2.extensions.register_type(BYTEA2BYTES)
```
makes it sow when you load the bytes from Postgres, they come in as type 'bytes' and not MemoryView
