### PR TITLE
Save headers and body as binary, Full Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ replaying the payload many times. grpc
 MemoryView  
 https://www.postgresql.org/message-id/25EDB20679154BDBB3CBBD335184E1D7%40frank  
 https://www.postgresql.org/message-id/C2C12FD0FCE64CE8BB77765A526D3C73%40frank  
+
+
+"Q. How to save a instance of a Class to the DB?"
+"A. You can't store the object itself in the DB. What you do is to store the data from the object and reconstruct it later."
+https://stackoverflow.com/questions/2047814/is-it-possible-to-store-python-class-objects-in-sqlite

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Send events using app.py to your on-prem instance. the middleware.go sniffs the 
 3. `sudo ./gor --input-raw :9000 --middleware "./middleware" --output-http http://localhost:9000/api/2/store`
 3. `python3 app.py` using ORIGINAL_DSN
 
+## TODO
+- once it all works, try using other sentry sdk's to produce events that get intercepted by flask/server.py
 
 ## Notes
 #### Sentry & buger's goreplay

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Sentry sdk sends events to a Flask API (like a proxy or interceptor) which then 
 3. `python app.py` using MODIFIED_dsn
 4. `localhost:9000` to see your Sentry onprem event
 
+Workflow:
+python app.py <-- sdk sends event to the intercetpor, which saves it in database (event never reaches Sentry instance)
+localhost:3001/impersonator <--- takes this event from the database and sends it along to Sentry instance
+
 #### doesnt' work yet
 Send events using app.py to your on-prem instance. the middleware.go sniffs the events and doesn't interrupt them like a proxy does.   
 1. `docker-compose up`
@@ -157,3 +161,6 @@ https://www.postgresql.org/message-id/C2C12FD0FCE64CE8BB77765A526D3C73%40frank
 "Q. How to save a instance of a Class to the DB?"
 "A. You can't store the object itself in the DB. What you do is to store the data from the object and reconstruct it later."
 https://stackoverflow.com/questions/2047814/is-it-possible-to-store-python-class-objects-in-sqlite
+
+
+Troubleshoot - compare len(bytes) on the way in as when it came out...

--- a/app.py
+++ b/app.py
@@ -5,11 +5,22 @@ import requests
 # from dotenv import load_dotenv
 # load_dotenv()
 
+# Unadulterated DSN, as provided by Sentry instance
+ORIGINAL_DSN = 'http://759bf0ad07984bb3941e677b35a13d2c@localhost:9000/2'
+
 # make sentry_sdk send the event to :3001 which is a Flask API and not Sentry.io
 MODIFIED_DSN = 'http://759bf0ad07984bb3941e677b35a13d2c@localhost:3001/2'
 
+def random():
+    print('something ramdom')
 def app():
-    sentry_sdk.capture_exception(Exception("middleman_11"))
+    random()
+    # TODO try raise Exception as well
+    sentry_sdk.capture_exception(Exception("longman_6"))
+
+    # Note - does not add stacktrace, even when you use random(). used ORIGINAL_DSN to test this
+    # random()
+    # sentry_sdk.capture_exception(Exception("longman_5Normal with random() "))
 
 def initialize_sentry():
     params = { 'dsn': MODIFIED_DSN }

--- a/flask/server.py
+++ b/flask/server.py
@@ -130,24 +130,19 @@ def event_bytea_get():
 
     with db.connect() as conn:
         results = conn.execute(
-            "SELECT * FROM events WHERE pk=13"
+            "SELECT * FROM events WHERE pk=15"
         ).fetchall()
         conn.close()
-        print('results[0]', results[0])
-
         row_proxy = results[0]
-        
         print('type(row_proxy)', type(row_proxy))
         print('row_proxy', row_proxy)
-        keys = row_proxy.keys()
- 
-        for key in keys:
-            print("key", key)
+        # keys = row_proxy.keys() 
+        # for key in keys:
+        #     print("key", key)
 
         print('row_proxy.data', row_proxy.data) # b'{ "foo": "bar" }'
         print('type(row_proxy.data)', type(row_proxy.data)) #'bytes' if you use the typecasting. 'MemoryView' if you don't use typecasting
-
-        return { "data": row_proxy.data.decode("utf-8")  }
+        return { "data": row_proxy.data.decode("utf-8"), "headers": row_proxy.headers }
 
 @app.route('/event-bytea', methods=['POST'])
 def event_bytea_post():
@@ -156,7 +151,6 @@ def event_bytea_post():
     print('type(request.headers)', type(request.headers)) # <class 'werkzeug.datastructures.EnvironHeaders'>
     # print('request.data', request.data) # b'{ "foo": "bar" }'
 
-
     request_headers = {}
     for key in ['Host','Accept-Encoding','Content-Length','Content-Encoding','Content-Type','User-Agent']:
         request_headers[key] = request.headers.get(key)
@@ -164,7 +158,6 @@ def event_bytea_post():
 
     insert_query = """ INSERT INTO events (type, name, data, headers) VALUES (%s,%s,%s,%s)"""
     record = ('python', 'example', request.data, json.dumps(request_headers)) # type(json.dumps(request_headers)) <type 'str'>
-
 
     with db.connect() as conn:
         conn.execute(insert_query, record)

--- a/flask/server.py
+++ b/flask/server.py
@@ -38,7 +38,7 @@ PASSWORD='admin'
 db = create_engine('postgresql://' + USERNAME + ':' + PASSWORD + '@' + HOST + ':5432/' + DATABASE)
 
 # Intercepts event from sentry sdk('s?) and saves to DB
-@app.route('/api/2/storeTEMP/', methods=['POST'])
+@app.route('/api/2/store/', methods=['POST'])
 def undertaker():
     print('type(request)', type(request)) # <class 'werkzeug.local.LocalProxy'
     print('type(request.headers)', type(request.headers)) # <class 'werkzeug.datastructures.EnvironHeaders'>

--- a/postgres.txt
+++ b/postgres.txt
@@ -38,6 +38,10 @@ INSERT INTO events (type, name)
 
 ALTER TABLE events
     ADD COLUMN data BYTEA;
+ALTER TABLE events
+    ADD COLUMN headers JSONB; <-- limited on chars. ~10,400,000 is rough limit. TEXT type available too. JSONB
+
+    ADD COLUMN data varchar(20000); <-- limited on chars. ~10,400,000 is rough limit. TEXT type available too. JSONB
 
 create user admin with login password 'admin';
 


### PR DESCRIPTION
`/api/2/store` is the new endpoint
it intercepts events from sdk and saves as bytes to database

Then...

hit
`/impersonator` which will load up those bytes from db and re-construct a payload to send to the Sentry instance

Note
`/api/2/storeOG/'` is the original endpoint this was spec'd out on, in previous weeks